### PR TITLE
Do not throw from Win32Helper.GetFocusedWindowHandle()

### DIFF
--- a/Source/ExcelDna.IntelliSense/Win32Helper.cs
+++ b/Source/ExcelDna.IntelliSense/Win32Helper.cs
@@ -133,7 +133,7 @@ namespace ExcelDna.IntelliSense
             var info = new GUITHREADINFO();
             info.cbSize = Marshal.SizeOf(info);
             if (!GetGUIThreadInfo(0, ref info))
-                throw new Win32Exception();
+                return IntPtr.Zero;
 
             var focusedWindow = info.hwndFocus;
             if (focusedWindow == IntPtr.Zero)
@@ -142,7 +142,7 @@ namespace ExcelDna.IntelliSense
             uint processId;
             uint threadId = GetWindowThreadProcessId(focusedWindow, out processId);
             if (threadId == 0)
-                throw new Win32Exception();
+                return IntPtr.Zero;
 
             uint currentProcessId = GetCurrentProcessId();
             if (processId == currentProcessId)


### PR DESCRIPTION
This function is called during initialization, from a background thread.
An exception there will crash Excel if not handled.

Note that there is at least one case where this happens :
when Excel launches on a locked desktop (typically through a scheduled task).

Since there are already some cases where this function will return IntPtr.Zero,
it makes sense to default to this, rather than catch at the calling site.