### PR TITLE
Add Source Code Link for `ExcelDna.IntelliSense` NuGet package

### DIFF
--- a/NuGet/ExcelDna.IntelliSense/ExcelDna.IntelliSense.nuspec
+++ b/NuGet/ExcelDna.IntelliSense/ExcelDna.IntelliSense.nuspec
@@ -7,6 +7,7 @@
         <authors>Excel-DNA Contributors</authors>
         <owners>Excel-DNA Contributors</owners>
         <projectUrl>http://excel-dna.net</projectUrl>
+        <repository type="git" url="https://github.com/Excel-DNA/IntelliSense" />
         <iconUrl>http://docs.excel-dna.net/NuGetIcon.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Excel-DNA IntelliSense is an extension library that provides on-sheet IntelliSense for Excel UDFs.</description>


### PR DESCRIPTION
This PR adds the `repository` element to the `.nuspec` files so that a link to this repo is displayed at nuget.org, as per [described in this post](https://blog.nuget.org/20180827/Introducing-Source-Code-Link-for-NuGet-packages.html).

![image](https://user-images.githubusercontent.com/177608/54481517-407d2580-4814-11e9-98bc-a4faab0e0c21.png)
