### PR TITLE
Fix possible crash in IntelliSenseServer.Uninstall()

### DIFF
--- a/Source/ExcelDna.IntelliSense/IntelliSenseServer.cs
+++ b/Source/ExcelDna.IntelliSense/IntelliSenseServer.cs
@@ -111,6 +111,8 @@ namespace ExcelDna.IntelliSense
         public static void Uninstall()
         {
             Logger.Initialization.Info($"IntelliSenseServer.Uninstall Begin: Version {ServerVersion} in {AppDomain.CurrentDomain.FriendlyName}");
+            if (IsDisabled())
+                return;
 
             UnpublishRegistration();
             if (_isActive)


### PR DESCRIPTION
If intellisense is disabled, `IntelliSenseServer.Install()` returns early, but not `IntelliSenseServer.Uninstall()`, which will then throw a `NullReferenceException` because environment variable `EXCELDNA_INTELLISENSE_SERVERS` has not been set.