### PR TITLE
Fix warning CS0649: Field 'UIState.SelectDataSource.SelectDataSourceWindow' is never assigned to...

### DIFF
--- a/Source/ExcelDna.IntelliSense/UIMonitor/UIState.cs
+++ b/Source/ExcelDna.IntelliSense/UIMonitor/UIState.cs
@@ -186,7 +186,7 @@ namespace ExcelDna.IntelliSense
         // Becomes a more general Window or Dialog to watch (for resize extension)
         public class SelectDataSource : UIState
         {
-            public IntPtr SelectDataSourceWindow;
+            public IntPtr SelectDataSourceWindow = IntPtr.Zero;
         }
 
         public override string ToString()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/177608/68362957-879b8c00-00ff-11ea-8c83-d83eaf2c62ac.png)


> Source\ExcelDna.IntelliSense\UIMonitor\UIState.cs(189,27,189,49): warning CS0649: Field 'UIState.SelectDataSource.SelectDataSourceWindow' is never assigned to, and will always have its default value
> 1>  ExcelDna.IntelliSense -> C:\caioproiete\excel-dna\IntelliSense\Source\ExcelDna.IntelliSense\bin\Debug\ExcelDna.IntelliSense.dll
