### PR TITLE
Update all projects to target ExcelDna v1.1.0-beta2

### DIFF
--- a/NuGet/ExcelDna.IntelliSense/ExcelDna.IntelliSense.nuspec
+++ b/NuGet/ExcelDna.IntelliSense/ExcelDna.IntelliSense.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>ExcelDna.IntelliSense</id>
-        <version>1.3.0-beta1</version>
+        <version>1.3.0-beta2</version>
         <title>Excel-DNA IntelliSense Extension</title>
         <authors>Excel-DNA Contributors</authors>
         <owners>Excel-DNA Contributors</owners>
@@ -14,7 +14,7 @@
         <summary>Excel-DNA IntelliSense is an extension library that can be added to an Excel-DNA add-in to provide an integrated IntelliSense server, providing IntelliSense services for all loaded Excel-DNA add-ins and appropriately configured VBA functions.</summary>
         <tags>excel exceldna udf excel-dna intellisense</tags>
         <dependencies>
-          <dependency id="ExcelDna.Integration" version="[1.1.0-beta1]" />
+          <dependency id="ExcelDna.Integration" version="1.1.0-beta2" />
         </dependencies>
     </metadata>
     <files>

--- a/Source/ExcelDna.IntelliSense.Host/ExcelDna.IntelliSense.Host.csproj
+++ b/Source/ExcelDna.IntelliSense.Host/ExcelDna.IntelliSense.Host.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ExcelDna.Integration, Version=1.1.0.0, Culture=neutral, PublicKeyToken=f225e9659857edbe, processorArchitecture=MSIL">
-      <HintPath>..\packages\ExcelDna.Integration.1.1.0-beta1\lib\ExcelDna.Integration.dll</HintPath>
+      <HintPath>..\packages\ExcelDna.Integration.1.1.0-beta2\lib\ExcelDna.Integration.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -68,12 +68,12 @@
     <None Include="App.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\ExcelDna.AddIn.1.1.0-beta1\build\ExcelDna.AddIn.targets" Condition="Exists('..\packages\ExcelDna.AddIn.1.1.0-beta1\build\ExcelDna.AddIn.targets')" />
+  <Import Project="..\packages\ExcelDna.AddIn.1.1.0-beta2\build\ExcelDna.AddIn.targets" Condition="Exists('..\packages\ExcelDna.AddIn.1.1.0-beta2\build\ExcelDna.AddIn.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\ExcelDna.AddIn.1.1.0-beta1\build\ExcelDna.AddIn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ExcelDna.AddIn.1.1.0-beta1\build\ExcelDna.AddIn.targets'))" />
+    <Error Condition="!Exists('..\packages\ExcelDna.AddIn.1.1.0-beta2\build\ExcelDna.AddIn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ExcelDna.AddIn.1.1.0-beta2\build\ExcelDna.AddIn.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/ExcelDna.IntelliSense.Host/packages.config
+++ b/Source/ExcelDna.IntelliSense.Host/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ExcelDna.AddIn" version="1.1.0-beta1" targetFramework="net40" developmentDependency="true" />
-  <package id="ExcelDna.Integration" version="1.1.0-beta1" targetFramework="net40" />
+  <package id="ExcelDna.AddIn" version="1.1.0-beta2" targetFramework="net40" developmentDependency="true" />
+  <package id="ExcelDna.Integration" version="1.1.0-beta2" targetFramework="net40" />
 </packages>

--- a/Source/ExcelDna.IntelliSense.Tools/ExcelDna.IntelliSense.Tools.csproj
+++ b/Source/ExcelDna.IntelliSense.Tools/ExcelDna.IntelliSense.Tools.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ExcelDna.Integration, Version=1.1.0.0, Culture=neutral, PublicKeyToken=f225e9659857edbe, processorArchitecture=MSIL">
-      <HintPath>..\packages\ExcelDna.Integration.1.1.0-beta1\lib\ExcelDna.Integration.dll</HintPath>
+      <HintPath>..\packages\ExcelDna.Integration.1.1.0-beta2\lib\ExcelDna.Integration.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -55,12 +55,12 @@
     <None Include="ExcelDna.IntelliSense.Tools-AddIn.dna" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\ExcelDna.AddIn.1.1.0-beta1\build\ExcelDna.AddIn.targets" Condition="Exists('..\packages\ExcelDna.AddIn.1.1.0-beta1\build\ExcelDna.AddIn.targets')" />
+  <Import Project="..\packages\ExcelDna.AddIn.1.1.0-beta2\build\ExcelDna.AddIn.targets" Condition="Exists('..\packages\ExcelDna.AddIn.1.1.0-beta2\build\ExcelDna.AddIn.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\ExcelDna.AddIn.1.1.0-beta1\build\ExcelDna.AddIn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ExcelDna.AddIn.1.1.0-beta1\build\ExcelDna.AddIn.targets'))" />
+    <Error Condition="!Exists('..\packages\ExcelDna.AddIn.1.1.0-beta2\build\ExcelDna.AddIn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ExcelDna.AddIn.1.1.0-beta2\build\ExcelDna.AddIn.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/ExcelDna.IntelliSense.Tools/packages.config
+++ b/Source/ExcelDna.IntelliSense.Tools/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ExcelDna.AddIn" version="1.1.0-beta1" targetFramework="net45" developmentDependency="true" />
-  <package id="ExcelDna.Integration" version="1.1.0-beta1" targetFramework="net45" />
+  <package id="ExcelDna.AddIn" version="1.1.0-beta2" targetFramework="net45" developmentDependency="true" />
+  <package id="ExcelDna.Integration" version="1.1.0-beta2" targetFramework="net45" />
 </packages>

--- a/Source/ExcelDna.IntelliSense/ExcelDna.IntelliSense.csproj
+++ b/Source/ExcelDna.IntelliSense/ExcelDna.IntelliSense.csproj
@@ -37,8 +37,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ExcelDna.Integration, Version=1.1.0.0, Culture=neutral, PublicKeyToken=f225e9659857edbe, processorArchitecture=MSIL">
-      <HintPath>..\packages\ExcelDna.Integration.1.1.0-beta1\lib\ExcelDna.Integration.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\packages\ExcelDna.Integration.1.1.0-beta2\lib\ExcelDna.Integration.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Office.Interop.Excel, Version=14.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
       <EmbedInteropTypes>True</EmbedInteropTypes>

--- a/Source/ExcelDna.IntelliSense/packages.config
+++ b/Source/ExcelDna.IntelliSense/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ExcelDna.Integration" version="1.1.0-beta1" targetFramework="net40" />
+  <package id="ExcelDna.Integration" version="1.1.0-beta2" targetFramework="net40" />
   <package id="ExcelDna.Interop" version="14.0.1" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
ExcelDna.IntelliSense `v1.1.0-beta1` is pinned to ExcelDna.Integration `v1.1.0-beta1` which blocks projects that use ExcelDna.IntelliSense from upgrading to ExcelDna.AddIn `v1.1.0-beta2`

![image](https://user-images.githubusercontent.com/177608/83610796-65170780-a556-11ea-8f10-241afa36657c.png)

This PR changes the dependency to `v1.1.0-beta2+` (_not_ pinned) to resolve this issue