### PR TITLE
Fixed some more edge cases where intellisense was not working in latest Excel.

### DIFF
--- a/Source/ExcelDna.IntelliSense/UIMonitor/WindowWatcher.cs
+++ b/Source/ExcelDna.IntelliSense/UIMonitor/WindowWatcher.cs
@@ -231,12 +231,14 @@ namespace ExcelDna.IntelliSense
             }
 
             var className = e.WindowClassName;
+            var windowHandle = e.WindowHandle;
 
-            if (e.EventType == WinEventHook.WinEvent.EVENT_SYSTEM_CAPTURESTART && !string.IsNullOrEmpty(_focusedWindowClassName))
+            if (e.EventType == WinEventHook.WinEvent.EVENT_SYSTEM_CAPTURESTART && !string.IsNullOrEmpty(_focusedWindowClassName) && _focusedWindowHandle != IntPtr.Zero)
             {
                 // Excel seems to always send this event to the XLMAIN window. However, it relates to user actions that happens inside the currently focused window.
                 // Thus, we relay this event to our recollection of the currently focused window.
                 className = _focusedWindowClassName;
+                windowHandle = _focusedWindowHandle;
             }
 
             // Debug.Print("### Thread receiving WindowStateChange: " + Thread.CurrentThread.ManagedThreadId);
@@ -250,16 +252,16 @@ namespace ExcelDna.IntelliSense
                 //    }
                 //    break;
                 case _popupListClass:
-                    PopupListWindowChanged?.Invoke(this, new WindowChangedEventArgs(e.WindowHandle, e.EventType, e.ObjectId));
+                    PopupListWindowChanged?.Invoke(this, new WindowChangedEventArgs(windowHandle, e.EventType, e.ObjectId));
                     break;
                 case _inCellEditClass:
-                    InCellEditWindowChanged?.Invoke(this, new WindowChangedEventArgs(e.WindowHandle, e.EventType, e.ObjectId));
+                    InCellEditWindowChanged?.Invoke(this, new WindowChangedEventArgs(windowHandle, e.EventType, e.ObjectId));
                     break;
                 case _formulaBarClass:
-                    FormulaBarWindowChanged?.Invoke(this, new WindowChangedEventArgs(e.WindowHandle, e.EventType, e.ObjectId));
+                    FormulaBarWindowChanged?.Invoke(this, new WindowChangedEventArgs(windowHandle, e.EventType, e.ObjectId));
                     break;
                 case _excelToolTipClass:
-                    ExcelToolTipWindowChanged?.Invoke(this, new WindowChangedEventArgs(e.WindowHandle, e.EventType, e.ObjectId));
+                    ExcelToolTipWindowChanged?.Invoke(this, new WindowChangedEventArgs(windowHandle, e.EventType, e.ObjectId));
                     break;
                 //case _nuiDialogClass:
                 //    // Debug.Print($"SelectDataSource {_selectDataSourceClass} Window update: {e.WindowHandle:X}, EventType: {e.EventType}, idChild: {e.ChildId}");


### PR DESCRIPTION
* I found some more cases where intellisense was not working properly. Sorry for not catching those in the first PR.
* I guess it makes sense that when we relay the event `EVENT_SYSTEM_CAPTURESTART` using `_focusedWindowClassName`, we should also pass in the `_focusedWindowHandle` instead of the handle to `XLMAIN`. It seems that not doing so caused a bit of confusion sometimes in the subscribed event handlers. That is fixed in this PR, such that 'faking' the capture event passes down both the focused hwnd and the focused class name together.
* Relates to #123